### PR TITLE
Mostrar productos que coincidan solamente con el texto ingresado #1

### DIFF
--- a/src/app/material-component/vendedor/vendedor.component.ts
+++ b/src/app/material-component/vendedor/vendedor.component.ts
@@ -117,7 +117,7 @@ export class VendedorComponent implements OnInit {
     valor = valor.trim();
     if (!!valor && valor.length > 0) {
       this.productos = this.todosProductos.filter((producto: Producto) => {
-        return producto.codigo.toLowerCase().includes(valor.toLowerCase());
+        return producto.codigo.toLowerCase().startsWith(valor.toLowerCase());
       });
     } else {
       console.log(this.todosProductos);


### PR DESCRIPTION
Atiende al Issue #1 para mostrar solamente productos que coincidan completamente con el texto ingresado. Anteriormente se buscaba dentro de la cadena el texto ingresado, ahora se verifica que coincida desde principio a fin.